### PR TITLE
Some changes on line number color and markdown inline code color.

### DIFF
--- a/jupyter.css
+++ b/jupyter.css
@@ -1,5 +1,3 @@
-/* i really want this to be global */
-
 /*-----------------------------------------------------------------------------
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
@@ -401,7 +399,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   padding: 0 3px 0 5px;
   min-width: 20px;
   text-align: right;
-  color: var(--atom-one-dark-gray);
+  color: var(--atom-one-dark-mono-1);
   white-space: nowrap;
 }
 
@@ -536,10 +534,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: var(--atom-one-dark-mo
     margin-bottom: 0;
     padding-left: var(--jp-code-padding);
     padding-right: var(--jp-code-padding);
-}
-
-.CodeMirror-linenumber {
-    color: var(--atom-one-dark-silver);
 }
 
 .cm-s-zenburn {

--- a/jupyter.css
+++ b/jupyter.css
@@ -524,6 +524,11 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: var(--atom-one-dark-mo
     border-bottom: 1px solid var(--atom-one-dark-fg);
 }
 
+/* Markdown inline code */
+.jp-RenderedHTMLCommon code {
+    background-color: var(--atom-one-dark-gray);
+    padding: 1px 3px;
+}
 
 .jp-MarkdownOutput {
     flex: 1 1 auto;
@@ -534,7 +539,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: var(--atom-one-dark-mo
 }
 
 .CodeMirror-linenumber {
-    color: var(--atom-one-dark-gray);
+    color: var(--atom-one-dark-silver);
 }
 
 .cm-s-zenburn {


### PR DESCRIPTION
The current line number color is too dark; maybe a brighter one is better.

And the markdown inline code looks too close to the normal text, adding a background for easier distinguishment.

![image](https://user-images.githubusercontent.com/20491264/44030973-033e9150-9f35-11e8-9e59-69e5b9b37acd.png)
